### PR TITLE
v3.1.0-h2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp_radio",
-  "version": "3.1.0",
+  "version": "3.1.0-h2",
   "description": "Japanese radio relay server for Volumio3",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/UIConfig.json
+++ b/src/UIConfig.json
@@ -134,6 +134,21 @@
               "label": "TRANSLATE.UI_SETTINGS.ALBUMART_TYPE3"
             }
           ]
+        },
+        {
+          "id": "stationLogoCache",
+          "element": "button",
+          "label": "TRANSLATE.UI_SETTINGS.STATION_LOGO_LABEL",
+          "doc": "TRANSLATE.UI_SETTINGS.STATION_LOGO_DOC",
+          "onClick": {
+            "type": "emit",
+            "message": "callMethod",
+            "data": {
+              "endpoint": "music_service/jp_radio",
+              "method": "clearStationLogoCache",
+              "data": ""
+            }
+          }
         }
       ]
     },

--- a/src/i18n/strings_ja.json
+++ b/src/i18n/strings_ja.json
@@ -26,7 +26,23 @@
     "TIMEFREE": "タイムフリー",
     "TIMEFREE_TODAY": "タイムフリー（本日分）",
     "TIMEFREE_FAVOURITES": "タイムフリー（お気に入り）",
+    "FAVOURITES_LIVE": "お気に入り局（ライブ）",
+    "FAVOURITES_TIMEFREE": "お気に入り番組（タイムフリー）",
+    "FAVOURITES_STATION": "お気に入り局（タイムフリー）",
+    "PROG_INFO": "番組情報：",
+    "PROG_FAVOURITES": "お気に入り局",
+    "PREV_WEEK": "▲　前週　▲",
+    "PREV_DAY" : "△　前日　△",
+    "NEXT_DAY" : "▽　翌日　▽",
+    "NEXT_WEEK": "▼　翌週　▼",
     "TODAY": "（今日）"
+  },
+  "PROGINFO": {
+    "PERFORMER": "出演者：",
+    "PROG_INFO": "番組情報：",
+    "PLAY": "▷ 再生",
+    "ADD_TO_QUEUE": "☰ キューに追加",
+    "ADD_TO_FAVOURITES": "♡ お気に入りに追加"
   },
   "UI_SETTINGS": {
     "PLUGIN_CONFIGURATION": "JP Radio Plugin設定",
@@ -48,6 +64,8 @@
     "ALBUMART_TYPE1": "バナー",
     "ALBUMART_TYPE2": "放送局ロゴ",
     "ALBUMART_TYPE3": "番組画像",
+    "STATION_LOGO_LABEL": "放送局ロゴキャッシュをクリア",
+    "STATION_LOGO_DOC": "タイムフリー時に使用する放送局ロゴのキャッシュファイルをクリアします。次回起動時に新しいロゴを再取得します。",
     "TIMEFREE_SETTING_LABEL": "タイムフリー設定",
     "PROGRAM_PERIOD_FROM_LABEL": "番組表の期間（〇日前から）",
     "PROGRAM_PERIOD_TO_LABEL":   "番組表の期間（〇日後まで）",

--- a/src/lib/models/BrowseResultModel.ts
+++ b/src/lib/models/BrowseResultModel.ts
@@ -6,8 +6,12 @@ export interface BrowseItem {
   type: string;
   // タイトル（例: 放送局名 + 番組名）
   title: string;
+  // 番組開始日時（yyyyMMddHHmmss）
+  time?: string;
   // 表示用の画像 URL（例: 局のロゴや番組アートワーク）
   albumart?: string;
+  // アイコン（albumartの代替）
+  icon?: string;
   // 選択時に再生や遷移に使用される URI
   uri: string;
   // プレイヤー内部で使われる任意の名前（未使用でも可）
@@ -22,6 +26,8 @@ export interface BrowseItem {
   channels?: number;
   // 番組時間（秒）
   duration?: number;
+  // お気に入り（バーガーメニューの制御用）
+  favourite?: boolean;
 }
 
 // Browse ページ内の 1 つのリスト（カテゴリや地域別に表示される）
@@ -32,6 +38,8 @@ export interface BrowseList {
   availableListViews: string[];
   // 表示されるアイテムの配列
   items: BrowseItem[];
+  // ソート用のキーワード（番組表を日付順に並べ替えるのに使用）
+  sortKey?: string;
 }
 
 // Volumio の UI に表示される全体構造（リストの配列 + 戻るリンクなど）
@@ -47,5 +55,5 @@ export interface BrowseResult {
   // ナビゲーション構造（リストや戻るリンクを含む）
   navigation: BrowseNavigation;
   // 現在の URI
-  uri: string;
+  uri?: string;
 }

--- a/src/lib/models/RadikoProgramModel.ts
+++ b/src/lib/models/RadikoProgramModel.ts
@@ -4,7 +4,7 @@ export interface RadikoProgramData {
   ft: string;
   to: string;
   title: string;
-  info?: string;  // TODO:
+  info?: string;
   pfm?: string;
   img?: string;
 }

--- a/src/lib/models/RadikoXMLStationModel.ts
+++ b/src/lib/models/RadikoXMLStationModel.ts
@@ -15,7 +15,7 @@ export interface RadikoXMLStation {
       '@ft': string;
       '@to': string;
       title: string;
-      info : string;  // TODO:
+      info : string;
       pfm  : string;
       img  : string;
     }[];


### PR DESCRIPTION
ライブ(お気に入り)／タイムフリー(お気に入り)を追加
タイムフリーのシーク改善
放送局ロゴの見栄え改善(白バックに変換)
再生画面「...」⇒「アーティストへ移動」で番組情報モーダル
番組表に「前週/前日/翌日/翌週」を追加
その他、細かい修正